### PR TITLE
Add simple Flask web UI for ElevenLabs streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ This provides a specialized player that:
 3. Plays the conversation with real-time audio streaming and playback
 4. Optionally saves the audio files while playing
 
+### Web UI (Live Streaming)
+
+You can also experiment directly from your browser:
+
+```bash
+python web_ui.py
+```
+
+Open `http://localhost:5000` and you'll see a simple page where you can type
+text, pick a voice and immediately stream the generated audio.
+
 ### Combining Audio Files
 
 After generating individual audio files, you can combine them into a single conversation file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ elevenlabs==0.2.27
 python-dotenv==1.0.0
 pydub==0.25.1
 pyaudio==0.2.13 
+Flask==2.3.2

--- a/web_ui.py
+++ b/web_ui.py
@@ -1,0 +1,82 @@
+import os
+from flask import Flask, render_template_string, request, Response
+from dotenv import load_dotenv
+from elevenlabs import stream, set_api_key
+from elevenlabs.api import Voices
+
+# Load API key from .env
+load_dotenv()
+api_key = os.getenv("ELEVENLABS_API_KEY")
+if not api_key:
+    raise RuntimeError("ELEVENLABS_API_KEY not set in environment")
+set_api_key(api_key)
+
+# Initialize Flask app
+app = Flask(__name__)
+
+# Fetch available voices once
+try:
+    voices = Voices.from_api()
+except Exception:
+    voices = []
+
+VOICE_NAMES = [v.name for v in voices] if voices else ["Rachel", "Daniel"]
+
+HTML_TEMPLATE = """
+<!doctype html>
+<html>
+<head>
+    <title>ElevenLabs Web Conversation</title>
+</head>
+<body>
+    <h1>ElevenLabs Web Conversation</h1>
+    <form id="speech-form">
+        <textarea id="text" rows="4" cols="60" placeholder="Enter text here"></textarea><br>
+        <label for="voice">Voice:</label>
+        <select id="voice">
+        {% for name in voice_names %}
+            <option value="{{ name }}">{{ name }}</option>
+        {% endfor %}
+        </select>
+        <button type="submit">Speak</button>
+    </form>
+    <audio id="player" controls></audio>
+    <script>
+    document.getElementById('speech-form').addEventListener('submit', function(e){
+        e.preventDefault();
+        const text = document.getElementById('text').value;
+        const voice = document.getElementById('voice').value;
+        const player = document.getElementById('player');
+        player.src = '/synthesize?text=' + encodeURIComponent(text) + '&voice=' + encodeURIComponent(voice);
+        player.play();
+    });
+    </script>
+</body>
+</html>
+"""
+
+@app.route('/')
+def index():
+    return render_template_string(HTML_TEMPLATE, voice_names=VOICE_NAMES)
+
+@app.route('/synthesize')
+def synthesize():
+    text = request.args.get('text', '')
+    voice_name = request.args.get('voice', VOICE_NAMES[0])
+    voice = next((v for v in voices if v.name == voice_name), voice_name)
+
+    audio_stream = stream(
+        text=text,
+        voice=voice,
+        model="eleven_multilingual_v2",
+        stream=True
+    )
+
+    def generate():
+        for chunk in audio_stream:
+            yield chunk
+
+    return Response(generate(), mimetype='audio/mpeg')
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- implement `web_ui.py` to expose streaming endpoint via Flask
- document new web interface in README
- add Flask to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d4f8dc07083219a5de2e413864fb2