### PR TITLE
Add web UI for streaming audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This application uses the ElevenLabs API to generate realistic audio conversatio
 - Combine individual audio files into a single conversation file
 - **NEW:** Stream audio in real-time using ElevenLabs' streaming API
 - **NEW:** Live playback of conversations with PyAudio
+- **NEW:** Web UI for streaming audio via LiveConversationPlayer
 
 ## Requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 elevenlabs==0.2.27
 python-dotenv==1.0.0
 pydub==0.25.1
-pyaudio==0.2.13 
+pyaudio==0.2.13
+flask==2.3.2

--- a/web_ui.py
+++ b/web_ui.py
@@ -1,0 +1,65 @@
+import os
+from flask import Flask, Response, request, render_template_string
+from dotenv import load_dotenv
+from elevenlabs import stream, set_api_key
+from stream_conversation import LiveConversationPlayer
+
+load_dotenv()
+api_key = os.getenv("ELEVENLABS_API_KEY")
+if not api_key:
+    raise RuntimeError("ELEVENLABS_API_KEY not set")
+set_api_key(api_key)
+
+# Use LiveConversationPlayer to fetch available voices
+player = LiveConversationPlayer()
+voices = player.get_available_voices()
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<title>Live Conversation Player</title>
+</head>
+<body>
+<h1>Live Conversation Player</h1>
+<textarea id='text' rows='4' cols='50' placeholder='Enter text here'></textarea><br>
+<select id='voice'>
+{% for v in voices %}
+<option value='{{ v.voice_id }}'>{{ v.name }}</option>
+{% endfor %}
+</select>
+<button onclick='play()'>Play</button>
+<audio id='audio' controls></audio>
+<script>
+function play() {
+  const text = document.getElementById('text').value;
+  const voice = document.getElementById('voice').value;
+  const audio = document.getElementById('audio');
+  audio.src = '/stream?text=' + encodeURIComponent(text) + '&voice=' + voice;
+  audio.play();
+}
+</script>
+</body>
+</html>
+"""
+
+@app.route('/')
+def index():
+    return render_template_string(INDEX_HTML, voices=voices)
+
+@app.route('/stream')
+def stream_audio():
+    text = request.args.get('text', '')
+    voice_id = request.args.get('voice')
+    selected = next((v for v in voices if v.voice_id == voice_id), voices[0])
+    audio_stream = stream(text=text, voice=selected, model="eleven_multilingual_v2", stream=True)
+    def generate():
+        for chunk in audio_stream:
+            yield chunk
+    return Response(generate(), mimetype='audio/mpeg')
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a Flask web app that uses `LiveConversationPlayer` to stream audio
- document the new web interface
- include Flask in requirements

## Testing
- `python -m py_compile web_ui.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684d4f8dc07083219a5de2e413864fb2