### PR TITLE
Fix stream argument error

### DIFF
--- a/conversation_generator.py
+++ b/conversation_generator.py
@@ -1,6 +1,6 @@
 import os
 import time
-from elevenlabs import stream, save, set_api_key
+from elevenlabs import generate, save, set_api_key
 from elevenlabs.api import Voices
 from dotenv import load_dotenv
 
@@ -65,7 +65,7 @@ def generate_conversation(conversation_list, output_dir="audio_output", play_aud
         
         try:
             # Generate audio using streaming
-            audio_stream = stream(
+            audio_stream = generate(
                 text=text,
                 voice=voice,
                 model="eleven_multilingual_v2",

--- a/custom_conversation.py
+++ b/custom_conversation.py
@@ -1,7 +1,7 @@
 import os
 import time
 import json
-from elevenlabs import stream, save, set_api_key
+from elevenlabs import generate, save, set_api_key
 from elevenlabs.api import Voices
 from dotenv import load_dotenv
 
@@ -164,7 +164,7 @@ class ConversationGenerator:
             
             try:
                 # Generate audio using streaming
-                audio_stream = stream(
+                audio_stream = generate(
                     text=text,
                     voice=voice,
                     model="eleven_multilingual_v2",

--- a/stream_conversation.py
+++ b/stream_conversation.py
@@ -5,7 +5,7 @@ import pyaudio
 import wave
 import io
 import tempfile
-from elevenlabs import stream, set_api_key
+from elevenlabs import generate, set_api_key
 from elevenlabs.api import Voices
 from dotenv import load_dotenv
 
@@ -176,7 +176,7 @@ class LiveConversationPlayer:
             
             try:
                 # Generate audio using streaming
-                audio_stream = stream(
+                audio_stream = generate(
                     text=text,
                     voice=voice,
                     model="eleven_multilingual_v2",
@@ -191,7 +191,7 @@ class LiveConversationPlayer:
                 # Save audio if directory specified
                 if save_dir:
                     # Re-generate the audio for saving (since we already consumed the stream)
-                    audio_stream = stream(
+                    audio_stream = generate(
                         text=text,
                         voice=voice,
                         model="eleven_multilingual_v2",

--- a/web_ui.py
+++ b/web_ui.py
@@ -2,7 +2,7 @@ import os
 
 from flask import Flask, Response, request, render_template_string
 from dotenv import load_dotenv
-from elevenlabs import stream, set_api_key
+from elevenlabs import generate, set_api_key
 from stream_conversation import LiveConversationPlayer
 
 load_dotenv()
@@ -57,11 +57,11 @@ def stream_audio():
     text = request.args.get('text', '')
     voice_id = request.args.get('voice')
     selected = next((v for v in voices if v.voice_id == voice_id), voices[0])
-    audio_stream = stream(text=text, voice=selected, model="eleven_multilingual_v2", stream=True)
-    def generate():
+    audio_stream = generate(text=text, voice=selected, model="eleven_multilingual_v2", stream=True)
+    def generate_chunks():
         for chunk in audio_stream:
             yield chunk
-    return Response(generate(), mimetype='audio/mpeg')
+    return Response(generate_chunks(), mimetype='audio/mpeg')
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- update examples to use `generate(..., stream=True)` instead of deprecated `stream()`
- rename helper function in `web_ui` to avoid name clash

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684d561b2ac48321add9120d987a23a4